### PR TITLE
feat(sales): 月別売上集計をSES台帳ベースで実装 (docs/460)

### DIFF
--- a/app/Http/Controllers/Api/DashboardController.php
+++ b/app/Http/Controllers/Api/DashboardController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Customer;
 use App\Models\Deal;
+use App\Models\MonthlySalesDetail;
 use App\Models\Task;
 use App\Models\Activity;
 use Illuminate\Support\Carbon;
@@ -134,10 +135,31 @@ class DashboardController extends Controller
                     : null,
             ]);
 
+        // 月別売上（過去6ヶ月）— SES台帳ベースの確定売上 (docs/460)。
+        // monthly_revenue (Deal ベース = 見込み) と並行表示する。集計済み明細を SUM するだけ。
+        $startKey  = $startOfWindow->year * 100 + $startOfWindow->month;
+        $salesRows = MonthlySalesDetail::query()
+            ->selectRaw('year, month, SUM(revenue) AS revenue, SUM(profit) AS profit')
+            ->whereRaw('(year * 100 + month) >= ?', [$startKey])
+            ->groupBy('year', 'month')
+            ->get()
+            ->keyBy(fn($r) => $r->year * 100 + $r->month);
+
+        $monthlySales = collect(range(5, 0))->map(function ($i) use ($now, $salesRows) {
+            $m   = $now->copy()->subMonths($i);
+            $row = $salesRows->get($m->year * 100 + $m->month);
+            return [
+                'month'   => $m->format('n月'),
+                'revenue' => (int) ($row->revenue ?? 0),
+                'profit'  => (int) ($row->profit ?? 0),
+            ];
+        })->values();
+
         return response()->json([
             'kpi'               => $kpi,
             'pipeline'          => $pipeline,
             'monthly_revenue'   => $monthlyRevenue,
+            'monthly_sales'     => $monthlySales,
             'upcoming_tasks'    => $upcomingTasks,
             'recent_activities' => $recentActivities,
             'won_deals'         => $wonDeals,

--- a/app/Http/Controllers/Api/MonthlySalesController.php
+++ b/app/Http/Controllers/Api/MonthlySalesController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\MonthlySalesDetail;
+use App\Services\MonthlySalesAggregationService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 月別売上集計 API (docs/460)。
+ *
+ * SES台帳 (ses_contracts) を起点に契約期間ベース・月単位粗計上で集計した
+ * monthly_sales_details を読む。ダッシュボードの Deal ベース見込み売上とは別系統 (並行表示)。
+ */
+class MonthlySalesController extends Controller
+{
+    public function __construct(private MonthlySalesAggregationService $aggregator) {}
+
+    /**
+     * 月別サマリ系列を返す。GET /api/v1/monthly-sales?months=6
+     * (MonthlySalesDetail は BelongsToTenant で自動的に現在テナントに絞られる)
+     */
+    public function index(Request $request)
+    {
+        $months = (int) $request->query('months', 6);
+        $months = max(1, min(36, $months));
+
+        $now   = Carbon::now();
+        $start = $now->copy()->subMonths($months - 1)->startOfMonth();
+
+        // (year, month) ごとに SUM。year*100+month の範囲で絞ると index を活用できる。
+        $startKey = $start->year * 100 + $start->month;
+
+        $rows = MonthlySalesDetail::query()
+            ->selectRaw('year, month, '
+                . 'SUM(revenue) AS revenue, SUM(cost) AS cost, SUM(profit) AS profit, '
+                . 'COUNT(*) AS detail_count')
+            ->whereRaw('(year * 100 + month) >= ?', [$startKey])
+            ->groupBy('year', 'month')
+            ->get()
+            ->keyBy(fn($r) => $r->year * 100 + $r->month);
+
+        // 欠けている月も 0 埋めして連続系列にする
+        $series = collect(range($months - 1, 0))->map(function ($i) use ($now, $rows) {
+            $m   = $now->copy()->subMonths($i);
+            $key = $m->year * 100 + $m->month;
+            $row = $rows->get($key);
+            return [
+                'year'         => (int) $m->year,
+                'month'        => (int) $m->month,
+                'label'        => $m->format('Y年n月'),
+                'revenue'      => (int) ($row->revenue ?? 0),
+                'cost'         => (int) ($row->cost ?? 0),
+                'profit'       => (int) ($row->profit ?? 0),
+                'detail_count' => (int) ($row->detail_count ?? 0),
+            ];
+        })->values();
+
+        return response()->json(['monthly_sales' => $series]);
+    }
+
+    /**
+     * 任意月の明細ドリルダウン。GET /api/v1/monthly-sales/{year}/{month}/details
+     */
+    public function details(int $year, int $month)
+    {
+        $details = MonthlySalesDetail::with(['sesContract:id,engineer_name,deal_id'])
+            ->where('year', $year)
+            ->where('month', $month)
+            ->orderByDesc('revenue')
+            ->get()
+            ->map(fn($d) => [
+                'ses_contract_id' => $d->ses_contract_id,
+                'engineer_name'   => $d->sesContract?->engineer_name,
+                'category'        => $d->category,
+                'revenue'         => (int) $d->revenue,
+                'cost'            => (int) $d->cost,
+                'profit'          => (int) $d->profit,
+            ]);
+
+        return response()->json([
+            'year'    => $year,
+            'month'   => $month,
+            'details' => $details,
+        ]);
+    }
+
+    /**
+     * 手動再集計。POST /api/v1/monthly-sales/recompute {year, month}
+     * 現在テナントの指定月のみ再集計する。
+     */
+    public function recompute(Request $request)
+    {
+        $validated = $request->validate([
+            'year'  => 'required|integer|min:2000|max:2100',
+            'month' => 'required|integer|min:1|max:12',
+        ]);
+
+        $tenantId = Auth::user()->tenant_id;
+
+        $result = $this->aggregator->aggregateMonth(
+            (int) $validated['year'],
+            (int) $validated['month'],
+            (int) $tenantId,
+        );
+
+        return response()->json($result);
+    }
+}

--- a/app/Models/MonthlySalesDetail.php
+++ b/app/Models/MonthlySalesDetail.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\BelongsToTenant;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * MonthlySalesDetail Model
+ *
+ * 月別売上集計の明細 (docs/460)。1 行 = (tenant, year, month, ses_contract)。
+ * 契約期間ベース・月単位粗計上で MonthlySalesAggregationService が生成する。
+ *
+ * @property int         $id
+ * @property int         $tenant_id
+ * @property int         $ses_contract_id
+ * @property int         $year
+ * @property int         $month
+ * @property string|null $category
+ * @property float       $revenue
+ * @property float       $cost
+ * @property float       $profit
+ * @property string      $computed_at
+ */
+class MonthlySalesDetail extends Model
+{
+    use BelongsToTenant;
+
+    protected $table = 'monthly_sales_details';
+
+    protected $fillable = [
+        'tenant_id',
+        'ses_contract_id',
+        'year',
+        'month',
+        'category',
+        'revenue',
+        'cost',
+        'profit',
+        'computed_at',
+    ];
+
+    protected $casts = [
+        'year'        => 'integer',
+        'month'       => 'integer',
+        'revenue'     => 'decimal:2',
+        'cost'        => 'decimal:2',
+        'profit'      => 'decimal:2',
+        'computed_at' => 'datetime',
+    ];
+
+    public function sesContract(): BelongsTo
+    {
+        return $this->belongsTo(SesContract::class);
+    }
+}

--- a/app/Services/MonthlySalesAggregationService.php
+++ b/app/Services/MonthlySalesAggregationService.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\MonthlySalesDetail;
+use App\Models\SesContract;
+use App\Scopes\TenantScope;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * 月別売上集計サービス (docs/460)。
+ *
+ * 設計判断 (2026-06-05 確定):
+ *  - 月の判定 = 契約期間ベース: contract_period_start〜end が対象月に重なる SES案件を計上。
+ *  - 月またぎ  = 月単位粗計上 : 1日でも重なれば全額をその月に計上 (按分なし)。
+ *  - 粒度      = 売上 (income_amount) + 仕入 (billing_plus_29) + 利益 (profit)。
+ *
+ * 再集計は対象 (tenant, year, month) の明細を delete → insert で作り直す (冪等)。
+ * tenantId=null のときは全テナント横断 (月初スケジュールバッチ用・Auth コンテキスト無し)。
+ */
+class MonthlySalesAggregationService
+{
+    /**
+     * 指定月を集計し直す。
+     *
+     * @param  int      $year
+     * @param  int      $month     1-12
+     * @param  int|null $tenantId  null=全テナント横断
+     * @return array{year:int, month:int, detail_count:int, total_revenue:float, total_cost:float, total_profit:float}
+     */
+    public function aggregateMonth(int $year, int $month, ?int $tenantId = null): array
+    {
+        $monthStart = Carbon::create($year, $month, 1)->startOfDay();
+        $monthEnd   = (clone $monthStart)->endOfMonth();
+        $now        = Carbon::now();
+
+        // 対象月に契約期間が重なる SES案件を抽出 (Auth に依存しないよう TenantScope を明示的に外す)。
+        //   重なり条件: start <= 月末 AND (end >= 月初 OR end IS NULL=継続中)
+        //   start が無い案件は月に置けないため除外。
+        $query = SesContract::withoutGlobalScope(TenantScope::class)
+            ->whereNotNull('contract_period_start')
+            ->whereDate('contract_period_start', '<=', $monthEnd->toDateString())
+            ->where(function ($q) use ($monthStart) {
+                $q->whereNull('contract_period_end')
+                  ->orWhereDate('contract_period_end', '>=', $monthStart->toDateString());
+            });
+
+        if ($tenantId !== null) {
+            $query->where('tenant_id', $tenantId);
+        }
+
+        $totals = ['detail_count' => 0, 'total_revenue' => 0.0, 'total_cost' => 0.0, 'total_profit' => 0.0];
+
+        DB::transaction(function () use ($query, $year, $month, $tenantId, $now, &$totals) {
+            // 既存の当月明細を削除 (冪等な作り直し)
+            $deleteQuery = MonthlySalesDetail::withoutGlobalScope(TenantScope::class)
+                ->where('year', $year)
+                ->where('month', $month);
+            if ($tenantId !== null) {
+                $deleteQuery->where('tenant_id', $tenantId);
+            }
+            $deleteQuery->delete();
+
+            $buffer = [];
+            foreach ($query->cursor() as $c) {
+                $revenue = (float) ($c->income_amount ?? 0);
+                $cost    = (float) ($c->billing_plus_29 ?? 0);
+                $profit  = (float) ($c->profit ?? 0);
+
+                $buffer[] = [
+                    'tenant_id'       => $c->tenant_id,
+                    'ses_contract_id' => $c->id,
+                    'year'            => $year,
+                    'month'           => $month,
+                    'category'        => $c->category,
+                    'revenue'         => $revenue,
+                    'cost'            => $cost,
+                    'profit'          => $profit,
+                    'computed_at'     => $now,
+                    'created_at'      => $now,
+                    'updated_at'      => $now,
+                ];
+
+                $totals['detail_count']++;
+                $totals['total_revenue'] += $revenue;
+                $totals['total_cost']    += $cost;
+                $totals['total_profit']  += $profit;
+
+                // 大量件数でもメモリを抑えるため 500 件ごとに flush
+                if (count($buffer) >= 500) {
+                    MonthlySalesDetail::insert($buffer);
+                    $buffer = [];
+                }
+            }
+            if ($buffer) {
+                MonthlySalesDetail::insert($buffer);
+            }
+        });
+
+        return [
+            'year'          => $year,
+            'month'         => $month,
+            'detail_count'  => $totals['detail_count'],
+            'total_revenue' => round($totals['total_revenue'], 2),
+            'total_cost'    => round($totals['total_cost'], 2),
+            'total_profit'  => round($totals['total_profit'], 2),
+        ];
+    }
+
+    /**
+     * 前月を全テナント分集計し直す (月初スケジュールバッチ用)。
+     *
+     * @return array{year:int, month:int, detail_count:int, total_revenue:float, total_cost:float, total_profit:float}
+     */
+    public function aggregatePreviousMonth(): array
+    {
+        $prev = Carbon::now()->subMonthNoOverflow();
+        return $this->aggregateMonth((int) $prev->year, (int) $prev->month, null);
+    }
+}

--- a/database/migrations/2026_06_05_123438_create_monthly_sales_details_table.php
+++ b/database/migrations/2026_06_05_123438_create_monthly_sales_details_table.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 月別売上集計の明細テーブル (docs/460)。
+ *
+ * 設計判断 (2026-06-05 確定):
+ *  - 月の判定: 契約期間ベース。contract_period_start〜end が対象月に重なる SES案件を計上。
+ *  - 月またぎ: 月単位で粗計上 (按分なし)。1日でも重なれば全額をその月に計上するため、
+ *    複数月にまたがる契約は各月に同額の明細行を持つ。
+ *  - 粒度: 売上 (revenue=income_amount) + 仕入 (cost=billing_plus_29) + 利益 (profit)。
+ *  - 真実のソースはこの明細。ダッシュボードのサマリは (tenant, year, month) で SUM して読む。
+ *
+ * (tenant_id, year, month, ses_contract_id) でユニーク。再集計は当月行を delete→insert。
+ *
+ * RLS: フロントは authenticated 経由 (supabase-js/Realtime) で読まず、Laravel API
+ *      (DashboardController / MonthlySalesController) 経由でのみ読むため authenticated GRANT は不要。
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('monthly_sales_details', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->onDelete('cascade');
+            $table->foreignId('ses_contract_id')->constrained()->onDelete('cascade');
+            $table->smallInteger('year');
+            $table->smallInteger('month'); // 1-12
+            // engineer / project (ses_contracts.category のスナップショット。内訳表示用)
+            $table->string('category', 20)->nullable();
+            $table->decimal('revenue', 12, 2)->default(0); // income_amount (顧客請求額・売上)
+            $table->decimal('cost', 12, 2)->default(0);    // billing_plus_29 (技術者支払額・仕入)
+            $table->decimal('profit', 12, 2)->default(0);  // profit (利益)
+            $table->timestamp('computed_at');
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'year', 'month', 'ses_contract_id'], 'monthly_sales_details_unique');
+            // サマリ集計用 (tenant + 期間の範囲検索)
+            $table->index(['tenant_id', 'year', 'month'], 'monthly_sales_details_tenant_period_idx');
+        });
+
+        // RLS / GRANT (CLAUDE.md ルール準拠)。sqlite テストではスキップ
+        if (DB::connection()->getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::statement('ALTER TABLE public.monthly_sales_details ENABLE ROW LEVEL SECURITY');
+        // test-postgres は service_role を持たないためガード
+        if (DB::selectOne("SELECT 1 AS x FROM pg_roles WHERE rolname = 'service_role'")) {
+            DB::statement('GRANT SELECT, INSERT, UPDATE, DELETE ON public.monthly_sales_details TO service_role');
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('monthly_sales_details');
+    }
+};

--- a/docs/460_monthly_sales_aggregation.md
+++ b/docs/460_monthly_sales_aggregation.md
@@ -1,8 +1,34 @@
-# 月別売上集計 機能設計メモ（将来実装）
+# 月別売上集計 機能設計メモ
 
-**ステータス**: 未着手 / 設計検討フェーズ
+**ステータス**: バックエンド実装済み (2026-06-05) / フロント UI 未着手
 **起票日**: 2026-05-16
 **起票背景**: ダッシュボード「月別売上」が `deals.updated_at` 基準で不正確。半期決算会議の月別売上集計は SES台帳ベースで行うべき。
+
+---
+
+## 実装サマリ (2026-06-05 / 論点1〜5 確定)
+
+確定設計: **契約期間ベース / 月単位粗計上 / 売上＋利益＋仕入 / Deal と並行表示 / 明細テーブル**。
+
+| 論点 | 決定 |
+|---|---|
+| 1 集計粒度 | (b) 売上(income_amount)+利益(profit)+仕入(billing_plus_29) |
+| 2 月の判定 | (a) 契約期間ベース: start<=月末 AND (end>=月初 OR end NULL) |
+| 3 月またぎ | (b) 月単位粗計上 (按分なし・各月に全額) |
+| 4 テーブル | (B) 明細テーブル `monthly_sales_details` を真実のソース。サマリは SUM |
+| 5 切替 | (b) 並行表示 (Deal ベース=見込み / SES ベース=確定) |
+
+実装ファイル:
+- `database/migrations/2026_06_05_123438_create_monthly_sales_details_table.php`
+- `app/Models/MonthlySalesDetail.php`
+- `app/Services/MonthlySalesAggregationService.php` — `aggregateMonth(year, month, ?tenantId)` / `aggregatePreviousMonth()`
+- `app/Http/Controllers/Api/MonthlySalesController.php` — index / details / recompute
+- ルート: `GET /api/v1/monthly-sales`, `GET /api/v1/monthly-sales/{year}/{month}/details`, `POST /api/v1/monthly-sales/recompute`
+- ダッシュボード `/api/v1/dashboard` に `monthly_sales` (SES確定売上6ヶ月) を追加
+- 月初バッチ: `routes/console.php` `aggregate-monthly-sales` (毎月1日 01:00 JST・全テナント前月再集計)
+- テスト: `tests/Pgsql/Feature/MonthlySalesAggregationTest.php` (重なり判定/月粗計上/cross-tenant/冪等性)
+
+**残**: フロント UI (月別売上ページ・手動再集計ボタン・ダッシュボード並行グラフ)。論点2(契約期間ベース)が既存 Excel 集計と一致するかは業務側ヒアリング推奨 (不一致なら work_month カラム新設 = 論点2(c) へ切替余地)。
 
 ---
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\ActivityController;
 use App\Http\Controllers\Api\TaskController;
 use App\Http\Controllers\Api\BusinessCardController;
 use App\Http\Controllers\Api\DashboardController;
+use App\Http\Controllers\Api\MonthlySalesController;
 use App\Http\Controllers\Api\NotificationController;
 use App\Http\Controllers\Api\GmailOAuthController;
 use App\Http\Controllers\Api\EmailController;
@@ -123,6 +124,11 @@ Route::prefix('v1')->middleware(['supabase.auth'])->group(function () {
     Route::get('email-body-templates/me',  [EmailBodyTemplateController::class, 'show']);
     Route::put('email-body-templates/me',  [EmailBodyTemplateController::class, 'upsert']);
     Route::get('dashboard', [DashboardController::class, 'index']);
+    // 月別売上集計 (SES台帳ベース・docs/460)
+    Route::get('monthly-sales',                          [MonthlySalesController::class, 'index']);
+    Route::get('monthly-sales/{year}/{month}/details',   [MonthlySalesController::class, 'details'])
+        ->whereNumber('year')->whereNumber('month');
+    Route::post('monthly-sales/recompute',               [MonthlySalesController::class, 'recompute']);
     Route::get('notifications', [NotificationController::class, 'index']);
     Route::post('notifications/mark-read', [NotificationController::class, 'markRead']);
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -214,6 +214,21 @@ Schedule::command('kagoya:purge-outsource --older-than-days=14 --execute --force
 //         Log::error('[Schedule] 分類済みメールのゴミ箱移動 失敗');
 //     });
 
+// ── 月別売上集計：前月分を全テナント再集計（毎月1日 1:00 JST・docs/460）
+// SES台帳(ses_contracts)を契約期間ベース・月単位粗計上で monthly_sales_details に確定。
+// 月初に前月が確定するため、当月 1 日に前月を一括集計する。Auth コンテキスト無し=全テナント横断。
+Schedule::call(function () {
+    $result = app(\App\Services\MonthlySalesAggregationService::class)->aggregatePreviousMonth();
+    Log::info('[Schedule] 月別売上集計 完了', $result);
+})
+    ->monthlyOn(1, '01:00')
+    ->timezone('Asia/Tokyo')
+    ->name('aggregate-monthly-sales')
+    ->withoutOverlapping()
+    ->onFailure(function () {
+        Log::error('[Schedule] aggregate-monthly-sales 失敗');
+    });
+
 // ── Vision API キーローテーション（90日毎 / 毎月1日 0:00）
 Schedule::command('vision:rotate-key')
     ->monthly()

--- a/tests/Pgsql/Feature/MonthlySalesAggregationTest.php
+++ b/tests/Pgsql/Feature/MonthlySalesAggregationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Tests\Pgsql\Feature;
+
+use App\Models\Customer;
+use App\Models\Deal;
+use App\Models\MonthlySalesDetail;
+use App\Models\SesContract;
+use App\Scopes\TenantScope;
+use App\Services\MonthlySalesAggregationService;
+use Carbon\Carbon;
+use Tests\Pgsql\PgsqlTestCase;
+
+/**
+ * MonthlySalesAggregationService の集計を PostgreSQL で検証する (docs/460)。
+ *
+ * 確定設計を pin する:
+ *  - 月の判定 = 契約期間ベース (start<=月末 AND (end>=月初 OR end NULL))
+ *  - 月またぎ = 月単位粗計上 (按分なし・各月に全額)
+ *  - cross-tenant (tenantId=null=全テナント / 指定時=当該テナントのみ)
+ *  - 再集計の冪等性 (delete→insert)
+ */
+class MonthlySalesAggregationTest extends PgsqlTestCase
+{
+    private function makeContract(int $tenantId, array $attrs): SesContract
+    {
+        $customer = Customer::factory()->create(['tenant_id' => $tenantId]);
+        $deal = Deal::factory()->create([
+            'tenant_id' => $tenantId, 'customer_id' => $customer->id, 'deal_type' => 'ses',
+        ]);
+        return SesContract::create(array_merge([
+            'tenant_id' => $tenantId,
+            'deal_id'   => $deal->id,
+        ], $attrs));
+    }
+
+    public function test_contract_period_overlap_decides_month_inclusion(): void
+    {
+        $this->actingAsUser(['role' => 'tenant_admin']);
+        $tenantId = $this->authUser->tenant_id;
+
+        // 当月(2026-05)に重なる
+        $this->makeContract($tenantId, [
+            'income_amount' => 500000, 'billing_plus_29' => 300000, 'profit' => 200000,
+            'contract_period_start' => '2026-04-15', 'contract_period_end' => '2026-06-10',
+        ]);
+        // 当月より前に終了 → 含まれない
+        $this->makeContract($tenantId, [
+            'income_amount' => 999999, 'profit' => 999999,
+            'contract_period_start' => '2026-01-01', 'contract_period_end' => '2026-04-30',
+        ]);
+        // 当月より後に開始 → 含まれない
+        $this->makeContract($tenantId, [
+            'income_amount' => 888888, 'profit' => 888888,
+            'contract_period_start' => '2026-06-01', 'contract_period_end' => '2026-12-31',
+        ]);
+        // end NULL (継続中) で start が当月以前 → 含まれる
+        $this->makeContract($tenantId, [
+            'income_amount' => 100000, 'billing_plus_29' => 60000, 'profit' => 40000,
+            'contract_period_start' => '2026-03-01', 'contract_period_end' => null,
+        ]);
+
+        $result = app(MonthlySalesAggregationService::class)->aggregateMonth(2026, 5, $tenantId);
+
+        $this->assertSame(2, $result['detail_count']);
+        $this->assertSame(600000.0, $result['total_revenue']); // 500000 + 100000
+        $this->assertSame(360000.0, $result['total_cost']);    // 300000 + 60000
+        $this->assertSame(240000.0, $result['total_profit']);  // 200000 + 40000
+    }
+
+    public function test_multi_month_contract_is_counted_gross_in_each_month(): void
+    {
+        $this->actingAsUser(['role' => 'tenant_admin']);
+        $tenantId = $this->authUser->tenant_id;
+
+        // 3ヶ月(4〜6月)にまたがる契約。按分せず各月に全額計上されること。
+        $this->makeContract($tenantId, [
+            'income_amount' => 700000, 'billing_plus_29' => 500000, 'profit' => 200000,
+            'contract_period_start' => '2026-04-10', 'contract_period_end' => '2026-06-20',
+        ]);
+
+        $svc = app(MonthlySalesAggregationService::class);
+        foreach ([4, 5, 6] as $m) {
+            $r = $svc->aggregateMonth(2026, $m, $tenantId);
+            $this->assertSame(1, $r['detail_count'], "month $m should include the contract");
+            $this->assertSame(700000.0, $r['total_revenue'], "month $m gross (no proration)");
+        }
+        // 範囲外の 3月・7月には計上されない
+        $this->assertSame(0, $svc->aggregateMonth(2026, 3, $tenantId)['detail_count']);
+        $this->assertSame(0, $svc->aggregateMonth(2026, 7, $tenantId)['detail_count']);
+    }
+
+    public function test_cross_tenant_scope(): void
+    {
+        $this->actingAsUser(['role' => 'tenant_admin']);
+        $tenantId = $this->authUser->tenant_id;
+        $other    = $this->createUserInAnotherTenant();
+
+        $this->makeContract($tenantId, [
+            'income_amount' => 500000, 'profit' => 100000,
+            'contract_period_start' => '2026-05-01', 'contract_period_end' => '2026-05-31',
+        ]);
+        $this->makeContract($other->tenant_id, [
+            'income_amount' => 300000, 'profit' => 80000,
+            'contract_period_start' => '2026-05-01', 'contract_period_end' => '2026-05-31',
+        ]);
+
+        $svc = app(MonthlySalesAggregationService::class);
+
+        // 自テナント指定 → 自分のみ
+        $mine = $svc->aggregateMonth(2026, 5, $tenantId);
+        $this->assertSame(1, $mine['detail_count']);
+        $this->assertSame(500000.0, $mine['total_revenue']);
+
+        // 全テナント横断 (null) → 両方
+        $all = $svc->aggregateMonth(2026, 5, null);
+        $this->assertSame(2, $all['detail_count']);
+        $this->assertSame(800000.0, $all['total_revenue']);
+    }
+
+    public function test_recompute_is_idempotent(): void
+    {
+        $this->actingAsUser(['role' => 'tenant_admin']);
+        $tenantId = $this->authUser->tenant_id;
+
+        $this->makeContract($tenantId, [
+            'income_amount' => 400000, 'profit' => 90000,
+            'contract_period_start' => '2026-05-01', 'contract_period_end' => '2026-05-31',
+        ]);
+
+        $svc = app(MonthlySalesAggregationService::class);
+        $svc->aggregateMonth(2026, 5, $tenantId);
+        $svc->aggregateMonth(2026, 5, $tenantId); // 2回目
+
+        // 重複行が増えていないこと
+        $count = MonthlySalesDetail::withoutGlobalScope(TenantScope::class)
+            ->where('tenant_id', $tenantId)->where('year', 2026)->where('month', 5)->count();
+        $this->assertSame(1, $count);
+    }
+}


### PR DESCRIPTION
## 概要
ダッシュボードの月別売上が `deals.updated_at` 基準で不正確だった問題に対し、SES台帳(`ses_contracts`)を起点とした**確定売上の月別集計**を追加します (docs/460)。Deal ベースの見込み売上は残し**並行表示**します。

## 確定設計 (論点1〜5)
| 論点 | 決定 |
|---|---|
| 集計粒度 | 売上(income_amount)+仕入(billing_plus_29)+利益(profit) |
| 月の判定 | 契約期間ベース: `start<=月末 AND (end>=月初 OR end NULL)` |
| 月またぎ | 月単位粗計上 (按分なし・各月に全額) |
| テーブル | 明細 `monthly_sales_details` を真実のソース、サマリはSUM |
| 切替 | Dealベース(見込み)と並行表示 |

## 変更
- **migration** `monthly_sales_details` (unique制約 + RLS + service_role GRANT)
- **MonthlySalesAggregationService** `aggregateMonth(year,month,?tenantId)` / `aggregatePreviousMonth()`。全テナント横断・冪等(delete→insert)
- **MonthlySalesController** 一覧サマリ / 明細ドリルダウン / 手動再集計
- **routes** `GET /monthly-sales`, `GET /monthly-sales/{year}/{month}/details`, `POST /monthly-sales/recompute`
- **DashboardController** `monthly_sales`(SES確定売上6ヶ月)を並行追加
- **月初バッチ** `aggregate-monthly-sales` (毎月1日 01:00 JST・前月を全テナント再集計)
- **Pgsqlテスト** 重なり判定 / 月粗計上 / cross-tenant / 冪等性 (4 passed)

## 検証
- ローカル migrate 完了・ルート配線確認
- 実データ集計: 78件中 May 2026 に65件、売上2,944万・利益816万、再実行で重複なし
- 新規テスト 4 passed (17 assertions)、既存 `SesContractSummaryTest` も緑

## 残・注意
- フロント UI (月別売上ページ・再集計ボタン・並行グラフ) は別途
- **論点2(契約期間ベース)が既存 Excel 集計と一致するか業務側ヒアリング推奨**。不一致なら `work_month` カラム新設(論点2(c))へ切替余地あり
- デプロイ時は migration 含むため `migrate --force` 必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)