### PR TITLE
feat(sales): 月別売上を年度ビュー化 + テナント決算情報 (docs/460)

### DIFF
--- a/app/Http/Controllers/Api/InvoiceIssuerController.php
+++ b/app/Http/Controllers/Api/InvoiceIssuerController.php
@@ -48,6 +48,9 @@ class InvoiceIssuerController extends Controller
         'invoice_issuer_bank_account_type',
         'invoice_issuer_bank_account_number',
         'invoice_issuer_bank_account_holder',
+        // 決算情報 (月別売上の年度・期算出に使用・docs/460)
+        'fiscal_year_end_month',
+        'first_period_fiscal_year',
     ];
 
     /** seal type → tenants カラム名 / Storage プレフィックス */
@@ -95,6 +98,9 @@ class InvoiceIssuerController extends Controller
             'invoice_issuer_bank_account_type'   => ['nullable', 'string', 'max:20'],
             'invoice_issuer_bank_account_number' => ['nullable', 'string', 'max:30'],
             'invoice_issuer_bank_account_holder' => ['nullable', 'string', 'max:100'],
+            // 決算情報 (docs/460)
+            'fiscal_year_end_month'    => ['nullable', 'integer', 'min:1', 'max:12'],
+            'first_period_fiscal_year' => ['nullable', 'integer', 'min:1900', 'max:2100'],
         ]);
 
         $tenant = Tenant::query()->findOrFail($user->tenant_id);

--- a/app/Http/Controllers/Api/MonthlySalesController.php
+++ b/app/Http/Controllers/Api/MonthlySalesController.php
@@ -26,41 +26,53 @@ class MonthlySalesController extends Controller
      */
     public function index(Request $request)
     {
-        $months = (int) $request->query('months', 6);
-        $months = max(1, min(36, $months));
+        $tenant = Auth::user()->tenant;
 
-        $now   = Carbon::now();
-        $start = $now->copy()->subMonths($months - 1)->startOfMonth();
+        // 年度 (決算月で終わる会計年度・終了月の暦年で表記)。未指定は当年度。
+        $fiscalYear = (int) $request->query('fiscal_year', $tenant->currentFiscalYear());
+        $monthsDef  = $tenant->fiscalYearMonths($fiscalYear); // [['year'=>..,'month'=>..] × 12]
 
-        // (year, month) ごとに SUM。year*100+month の範囲で絞ると index を活用できる。
-        $startKey = $start->year * 100 + $start->month;
+        // 対象 12 ヶ月の (year,month) を SUM。year*100+month キーで引く。
+        $minKey = $monthsDef[0]['year'] * 100 + $monthsDef[0]['month'];
+        $maxKey = $monthsDef[11]['year'] * 100 + $monthsDef[11]['month'];
 
         $rows = MonthlySalesDetail::query()
             ->selectRaw('year, month, '
                 . 'SUM(revenue) AS revenue, SUM(cost) AS cost, SUM(profit) AS profit, '
                 . 'COUNT(*) AS detail_count')
-            ->whereRaw('(year * 100 + month) >= ?', [$startKey])
+            ->whereRaw('(year * 100 + month) BETWEEN ? AND ?', [$minKey, $maxKey])
             ->groupBy('year', 'month')
             ->get()
             ->keyBy(fn($r) => $r->year * 100 + $r->month);
 
-        // 欠けている月も 0 埋めして連続系列にする
-        $series = collect(range($months - 1, 0))->map(function ($i) use ($now, $rows) {
-            $m   = $now->copy()->subMonths($i);
-            $key = $m->year * 100 + $m->month;
-            $row = $rows->get($key);
+        $total = ['revenue' => 0, 'cost' => 0, 'profit' => 0, 'detail_count' => 0];
+
+        $series = collect($monthsDef)->map(function ($mn) use ($rows, &$total) {
+            $row = $rows->get($mn['year'] * 100 + $mn['month']);
+            $rev = (int) ($row->revenue ?? 0);
+            $cst = (int) ($row->cost ?? 0);
+            $prf = (int) ($row->profit ?? 0);
+            $cnt = (int) ($row->detail_count ?? 0);
+            $total['revenue'] += $rev; $total['cost'] += $cst;
+            $total['profit']  += $prf; $total['detail_count'] += $cnt;
             return [
-                'year'         => (int) $m->year,
-                'month'        => (int) $m->month,
-                'label'        => $m->format('Y年n月'),
-                'revenue'      => (int) ($row->revenue ?? 0),
-                'cost'         => (int) ($row->cost ?? 0),
-                'profit'       => (int) ($row->profit ?? 0),
-                'detail_count' => (int) ($row->detail_count ?? 0),
+                'year'         => $mn['year'],
+                'month'        => $mn['month'],
+                'label'        => "{$mn['year']}年{$mn['month']}月",
+                'revenue'      => $rev,
+                'cost'         => $cst,
+                'profit'       => $prf,
+                'detail_count' => $cnt,
             ];
         })->values();
 
-        return response()->json(['monthly_sales' => $series]);
+        return response()->json([
+            'fiscal_year'           => $fiscalYear,
+            'period'                => $tenant->periodFor($fiscalYear),  // 期 (未設定なら null)
+            'fiscal_year_end_month' => $tenant->fiscalEndMonth(),
+            'monthly_sales'         => $series,
+            'total'                 => $total,
+        ]);
     }
 
     /**
@@ -90,24 +102,43 @@ class MonthlySalesController extends Controller
     }
 
     /**
-     * 手動再集計。POST /api/v1/monthly-sales/recompute {year, month}
-     * 現在テナントの指定月のみ再集計する。
+     * 手動再集計。POST /api/v1/monthly-sales/recompute
+     *   - { fiscal_year } 指定時: その年度の 12 ヶ月をまとめて再集計
+     *   - { year, month } 指定時: 単月のみ再集計
+     * 現在テナント分のみ。
      */
     public function recompute(Request $request)
     {
-        $validated = $request->validate([
-            'year'  => 'required|integer|min:2000|max:2100',
-            'month' => 'required|integer|min:1|max:12',
+        $user     = Auth::user();
+        $tenantId = (int) $user->tenant_id;
+
+        // 単月指定があれば単月、なければ年度まとめて
+        if ($request->filled('month')) {
+            $validated = $request->validate([
+                'year'  => 'required|integer|min:2000|max:2100',
+                'month' => 'required|integer|min:1|max:12',
+            ]);
+            $result = $this->aggregator->aggregateMonth(
+                (int) $validated['year'], (int) $validated['month'], $tenantId,
+            );
+            return response()->json($result);
+        }
+
+        $validated  = $request->validate([
+            'fiscal_year' => 'required|integer|min:2000|max:2100',
         ]);
+        $fiscalYear = (int) $validated['fiscal_year'];
+        $months     = $user->tenant->fiscalYearMonths($fiscalYear);
 
-        $tenantId = Auth::user()->tenant_id;
+        $total = ['detail_count' => 0, 'total_revenue' => 0.0, 'total_cost' => 0.0, 'total_profit' => 0.0];
+        foreach ($months as $mn) {
+            $r = $this->aggregator->aggregateMonth($mn['year'], $mn['month'], $tenantId);
+            $total['detail_count']  += $r['detail_count'];
+            $total['total_revenue'] += $r['total_revenue'];
+            $total['total_cost']    += $r['total_cost'];
+            $total['total_profit']  += $r['total_profit'];
+        }
 
-        $result = $this->aggregator->aggregateMonth(
-            (int) $validated['year'],
-            (int) $validated['month'],
-            (int) $tenantId,
-        );
-
-        return response()->json($result);
+        return response()->json(array_merge(['fiscal_year' => $fiscalYear], $total));
     }
 }

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -11,6 +11,7 @@ class Tenant extends Model
 
     protected $fillable = [
         'name', 'slug', 'plan', 'is_active', 'ses_enabled', 'feature_requirement_matching',
+        'fiscal_year_end_month', 'first_period_fiscal_year',
         'invoice_issuer_name',
         'invoice_issuer_postal_code',
         'invoice_issuer_address',
@@ -42,7 +43,52 @@ class Tenant extends Model
     protected $casts = [
         'ses_enabled'                  => 'boolean',
         'feature_requirement_matching' => 'boolean',
+        'fiscal_year_end_month'        => 'integer',
+        'first_period_fiscal_year'     => 'integer',
     ];
+
+    // ── 会計年度ヘルパー (docs/460) ────────────────────────────
+    // 「年度」= 決算月で終わる会計年度を、その終了月の暦年で表す
+    // (9月決算なら 2025-10〜2026-09 = 2026年度)。決算月未設定なら暦年(12月)扱い。
+
+    /** 決算月 (1-12)。未設定なら 12 (暦年) を返す */
+    public function fiscalEndMonth(): int
+    {
+        $m = $this->fiscal_year_end_month;
+        return ($m >= 1 && $m <= 12) ? (int) $m : 12;
+    }
+
+    /** 指定日 (既定=今日) が属する年度を返す */
+    public function currentFiscalYear(?\Carbon\Carbon $date = null): int
+    {
+        $date = $date ?? \Carbon\Carbon::now();
+        $end  = $this->fiscalEndMonth();
+        // 終了月までは当年が年度、超えたら翌年が年度
+        return $date->month <= $end ? (int) $date->year : (int) $date->year + 1;
+    }
+
+    /** 年度に属する 12 ヶ月を時系列 [['year'=>..,'month'=>..], ...] で返す */
+    public function fiscalYearMonths(int $fiscalYear): array
+    {
+        $end        = $this->fiscalEndMonth();
+        $startMonth = ($end % 12) + 1;             // 決算月の翌月
+        $startYear  = $end === 12 ? $fiscalYear : $fiscalYear - 1;
+
+        $months = [];
+        for ($i = 0; $i < 12; $i++) {
+            $m = $startMonth + $i;
+            $y = $startYear + intdiv($m - 1, 12);
+            $months[] = ['year' => $y, 'month' => (($m - 1) % 12) + 1];
+        }
+        return $months;
+    }
+
+    /** 年度に対応する「期」。第1期年度が未設定なら null */
+    public function periodFor(int $fiscalYear): ?int
+    {
+        $base = $this->first_period_fiscal_year;
+        return $base ? $fiscalYear - (int) $base + 1 : null;
+    }
 
     public function users(): HasMany
     {

--- a/database/migrations/2026_06_05_131904_add_fiscal_settings_to_tenants.php
+++ b/database/migrations/2026_06_05_131904_add_fiscal_settings_to_tenants.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * テナントに決算情報を追加 (docs/460 月別売上の年度ビュー用)。
+ *
+ * - fiscal_year_end_month: 決算月 (1-12)。例 9 = 9月決算 → 年度は 10月〜翌9月。
+ * - first_period_fiscal_year: 第1期の年度。期 = 年度 - first_period_fiscal_year + 1。
+ *   例 2011 なら 2026年度 = 16期。
+ *
+ * 「年度」は決算月で終わる会計年度を、その終了月の暦年で表す
+ * (9月決算なら 2025-10〜2026-09 = 2026年度)。
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->smallInteger('fiscal_year_end_month')->nullable()->after('ses_enabled');
+            $table->smallInteger('first_period_fiscal_year')->nullable()->after('fiscal_year_end_month');
+        });
+
+        // 自社テナント (aizen / tenant_id=1) を 9月決算・第1期=2011年度 で初期化。
+        // 他テナントは null のまま (フロントは未設定なら暦年フォールバック)。
+        DB::table('tenants')->where('id', 1)->update([
+            'fiscal_year_end_month'    => 9,
+            'first_period_fiscal_year' => 2011,
+        ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('tenants', function (Blueprint $table) {
+            $table->dropColumn(['fiscal_year_end_month', 'first_period_fiscal_year']);
+        });
+    }
+};

--- a/tests/Pgsql/Feature/MonthlySalesAggregationTest.php
+++ b/tests/Pgsql/Feature/MonthlySalesAggregationTest.php
@@ -118,6 +118,24 @@ class MonthlySalesAggregationTest extends PgsqlTestCase
         $this->assertSame(800000.0, $all['total_revenue']);
     }
 
+    public function test_fiscal_year_helpers(): void
+    {
+        $this->actingAsUser(['role' => 'tenant_admin']);
+        $tenant = $this->authUser->tenant;
+        $tenant->update(['fiscal_year_end_month' => 9, 'first_period_fiscal_year' => 2011]);
+        $tenant->refresh();
+
+        // 9月決算: 2025-10〜2026-09 = 2026年度 = 16期
+        $this->assertSame(2026, $tenant->currentFiscalYear(\Carbon\Carbon::parse('2026-06-05')));
+        $this->assertSame(2027, $tenant->currentFiscalYear(\Carbon\Carbon::parse('2026-11-01'))); // 10月超で翌年度
+        $this->assertSame(16, $tenant->periodFor(2026));
+
+        $months = $tenant->fiscalYearMonths(2026);
+        $this->assertCount(12, $months);
+        $this->assertSame(['year' => 2025, 'month' => 10], $months[0]);
+        $this->assertSame(['year' => 2026, 'month' => 9], $months[11]);
+    }
+
     public function test_recompute_is_idempotent(): void
     {
         $this->actingAsUser(['role' => 'tenant_admin']);


### PR DESCRIPTION
## 概要
月別売上を**会計年度（決算月で区切り）・期**で集計/表示できるようにする。年度・期はハードコードせず**テナント決算設定から算出**。

## 変更
- **tenants** に `fiscal_year_end_month`(決算月) / `first_period_fiscal_year`(第1期の年度) を追加。自社テナント(aizen)を 9月決算・第1期2011年度 で初期化
- **Tenant** ヘルパー: `currentFiscalYear` / `fiscalYearMonths` / `periodFor`
  - 年度 = 決算月で終わる会計年度を終了月の暦年で表記（9月決算 → 2025/10〜2026/9 = 2026年度）
  - 期 = 年度 − 第1期年度 + 1（2026年度 = 16期）
- **MonthlySalesController::index** を年度ビュー化（`fiscal_year` パラメータ・12ヶ月＋合計＋期を返却）
- **recompute** を年度まとめて再集計に対応（`fiscal_year` 指定。単月 `{year,month}` も後方互換）
- **InvoiceIssuerController（請求書発行元設定）** の show/update に決算情報を追加

## 検証
- Pgsqlテスト 5 passed（重なり判定/月粗計上/cross-tenant/**年度・期算出**/冪等性）
- PHP 構文OK

## デプロイ
- migration を含む（`migrate --force` 必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)