### PR TITLE
feat(emails): 一覧を到着(取込)時刻順に変更（Kagoya配送遅延の鮮度問題）

### DIFF
--- a/app/Http/Controllers/Api/EmailController.php
+++ b/app/Http/Controllers/Api/EmailController.php
@@ -56,8 +56,11 @@ class EmailController extends Controller
         if ($searchBody && mb_strlen((string) $search) < 5) {
             $searchBody = false;
         }
+        // 並びは created_at(取込≒到着時刻) 降順。Kagoya の配送遅延で received_at(送信時刻)が
+        // 実際の到着より古くなり、一覧が webmail より古く見える問題への対処 (2026-06-05)。
+        // received_at の意味 (スコア/既読/スレッド基準) は不変。created_at index で高速化済。
         $query = Email::query()
-            ->orderBy('received_at', 'desc');
+            ->orderBy('created_at', 'desc');
         if ($search) {
             $query->where(function ($q) use ($search, $searchBody) {
                 // PostgreSQL では ilike で大文字小文字を区別しない部分一致（他コントローラと統一）

--- a/database/migrations/2026_06_05_154546_add_created_at_index_to_emails.php
+++ b/database/migrations/2026_06_05_154546_add_created_at_index_to_emails.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * メール一覧を「到着(取込)時刻」順で表示するための created_at index。
+ *
+ * 背景: Kagoya の配送遅延(キュー滞留・最大数時間)で received_at(=Date ヘッダ=送信時刻)が
+ * 実際の到着より大きく古くなり、営業から見ると一覧が webmail より古く見える問題。
+ * 一覧の並びを created_at(=取込時刻≒到着) に変更する (EmailController::index)。
+ * received_at の意味 (スコア/既読/スレッド基準) は変えない。
+ *
+ * created_at は INSERT 専用 (更新されない) ため、is_read の HOT 更新を阻害しない
+ * (HOT 最適化と両立)。INSERT 時の btree 追加コストのみ。
+ * 既存の received_at 複合 index に対応する 2 本を作成。
+ *
+ * 本番テーブル (約20万行・高頻度 insert) のため CONCURRENTLY。transaction 不可。
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (DB::connection()->getDriverName() !== 'pgsql') return;
+        DB::statement('SET statement_timeout = 0');
+        DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS emails_tenant_created_at_idx '
+            . 'ON public.emails USING btree (tenant_id, created_at DESC)');
+        DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS emails_tenant_category_created_at_idx '
+            . 'ON public.emails USING btree (tenant_id, category, created_at DESC)');
+    }
+
+    public function down(): void
+    {
+        if (DB::connection()->getDriverName() !== 'pgsql') return;
+        DB::statement('SET statement_timeout = 0');
+        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS public.emails_tenant_created_at_idx');
+        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS public.emails_tenant_category_created_at_idx');
+    }
+};


### PR DESCRIPTION
## 背景
Kagoya の配送遅延（キュー滞留・数時間）で `received_at`（=Date ヘッダ=送信時刻）が実際の到着より古くなり、営業視点でメール一覧が Kagoya webmail より古く見える（例: 最新 12:07 vs webmail 15:36）。取込自体は遅れていない（created_at は直近）。

## 変更
- `EmailController::index` の並びを `received_at` → **`created_at`（取込≒到着）降順**に変更。`received_at` の意味（スコア/既読/スレッド基準）は不変。
- `created_at` 複合 index 2本を **CONCURRENTLY** 追加（`(tenant_id, created_at)` / `(tenant_id, category, created_at)`）。`created_at` は INSERT 専用のため **is_read の HOT 更新を阻害しない**。
- フロント `/emails`: 一覧の時刻表示を取込時刻に、詳細は「取込」「送信」を併記（フロントは別PR）。

## 検証
- EXPLAIN: `emails_tenant_created_at_idx` 使用・Index Scan・ソート無し（高速）
- `EmailSearchTest` green

## デプロイ
- migration あり（CONCURRENTLY・非ブロッキング）。`migrate --force` 必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)