### PR TITLE
feat(emails): 受信時刻(INTERNALDATE)を arrived_at に保存・一覧並びに使用 + 取込5分

### DIFF
--- a/app/Http/Controllers/Api/EmailController.php
+++ b/app/Http/Controllers/Api/EmailController.php
@@ -56,11 +56,11 @@ class EmailController extends Controller
         if ($searchBody && mb_strlen((string) $search) < 5) {
             $searchBody = false;
         }
-        // 並びは created_at(取込≒到着時刻) 降順。Kagoya の配送遅延で received_at(送信時刻)が
-        // 実際の到着より古くなり、一覧が webmail より古く見える問題への対処 (2026-06-05)。
-        // received_at の意味 (スコア/既読/スレッド基準) は不変。created_at index で高速化済。
+        // 並びは arrived_at(IMAP INTERNALDATE=Kagoya 着信時刻=webmail 表示と一致) 降順。
+        // Kagoya 配送遅延で received_at(送信時刻)が古くなる問題への対処 (2026-06-05)。
+        // received_at の意味 (スコア/既読/スレッド基準) は不変。arrived_at index で高速化済。
         $query = Email::query()
-            ->orderBy('created_at', 'desc');
+            ->orderBy('arrived_at', 'desc');
         if ($search) {
             $query->where(function ($q) use ($search, $searchBody) {
                 // PostgreSQL では ilike で大文字小文字を区別しない部分一致（他コントローラと統一）

--- a/app/Models/Email.php
+++ b/app/Models/Email.php
@@ -47,6 +47,7 @@ class Email extends Model
         'body_text',
         'body_html',
         'received_at',
+        'arrived_at',
         'is_read',
         'contact_id',
         'deal_id',
@@ -64,6 +65,7 @@ class Email extends Model
 
     protected $casts = [
         'received_at'    => 'datetime',
+        'arrived_at'     => 'datetime',
         'is_read'        => 'boolean',
         'extracted_data' => 'array',
         'classified_at'   => 'datetime',

--- a/app/Services/KagoyaMailService.php
+++ b/app/Services/KagoyaMailService.php
@@ -253,6 +253,13 @@ class KagoyaMailService
                 ? Carbon::parse($internalDate)->utc()
                 : Carbon::now()->utc());
 
+        // 到着時刻 = INTERNALDATE (Kagoya メールボックス着信時刻 = webmail 表示と一致)。
+        // 一覧の並び/「受信」表示に使う。Kagoya 配送遅延があっても webmail と同じ鮮度になる。
+        // INTERNALDATE が取れない場合は received_at(送信時刻)で代替。
+        $arrivedAt = $internalDate
+            ? Carbon::parse($internalDate)->utc()
+            : $receivedAt;
+
         // バウンスメール（不達通知）/ 上流スパム判定済みメールは category='bounce' の
         // 最小 stub だけ保存し、本文/添付処理はスキップ。
         // 旧実装は何も保存しなかったため、毎回 IMAP から同じ UID が「新着」として返り
@@ -288,6 +295,7 @@ class KagoyaMailService
                 'body_text'        => null,
                 'body_html'        => null,
                 'received_at'      => $receivedAt,
+                'arrived_at'       => $arrivedAt,
                 'is_read'          => true,    // 未読カウントを汚さない
                 'category'         => 'bounce', // classifyPending(whereNull) に拾わせない
                 'classified_at'    => $receivedAt,
@@ -334,6 +342,7 @@ class KagoyaMailService
             'body_text'        => $bodyText,
             'body_html'        => $bodyHtml,
             'received_at'      => $receivedAt,
+            'arrived_at'       => $arrivedAt,
             // self の場合は未読カウントを汚さず classifyPending(whereNull) にも拾わせない
             // forceSelf 以外でも、ユーザーが直近 markAllRead を実行済 (received_at < finished_at) なら既読扱い
             'is_read'          => $forceSelf || $alreadyMarkedRead,

--- a/database/factories/EmailFactory.php
+++ b/database/factories/EmailFactory.php
@@ -18,7 +18,8 @@ class EmailFactory extends Factory
             'from_name'        => fake()->name(),
             'to_address'       => fake()->safeEmail(),
             'body_text'        => fake()->paragraph(),
-            'received_at'      => fake()->dateTimeBetween('-30 days', 'now'),
+            'received_at'      => $received = fake()->dateTimeBetween('-30 days', 'now'),
+            'arrived_at'       => $received,
             'is_read'          => false,
         ];
     }

--- a/database/migrations/2026_06_05_160042_add_arrived_at_to_emails.php
+++ b/database/migrations/2026_06_05_160042_add_arrived_at_to_emails.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * emails.arrived_at = IMAP INTERNALDATE (Kagoya メールボックス着信時刻 = webmail 表示と一致)。
+ *
+ * 背景: received_at は Date ヘッダ(送信時刻)で、Kagoya の配送遅延により実到着より古い。
+ * created_at(取込時刻)はポーリング(5分)ラグを含む。webmail と完全一致する到着時刻が欲しいので
+ * INTERNALDATE を専用カラムに保存し、一覧の並び/「受信」表示に使う。
+ *
+ * 手順 (本番 hot テーブル・約20万行):
+ *  1) カラム追加 (nullable・メタデータのみで即時)
+ *  2) 既存行を arrived_at = created_at で backfill (INTERNALDATE 未保存のため取込時刻で代用)。
+ *     index 作成前なので arrived_at 更新は HOT で軽量。LIMIT バッチで statement_timeout 回避。
+ *  3) arrived_at 複合 index を CONCURRENTLY 作成 (received_at 系と同形)
+ *  4) 先行で追加した created_at 並び替え index を撤去 (arrived_at 並びへ移行・dead index 化を防ぐ)
+ *
+ * CONCURRENTLY を含むため $withinTransaction = false。
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        // 1) カラム追加 (sqlite テスト含め portable)
+        if (!Schema::hasColumn('emails', 'arrived_at')) {
+            Schema::table('emails', function (Blueprint $table) {
+                $table->timestamp('arrived_at')->nullable()->after('received_at');
+            });
+        }
+
+        if (DB::connection()->getDriverName() !== 'pgsql') return;
+
+        DB::statement('SET statement_timeout = 0');
+
+        // 2) backfill (index 作成前 = HOT・LIMIT バッチ)
+        do {
+            $n = DB::update(
+                'UPDATE public.emails SET arrived_at = created_at '
+                . 'WHERE id IN (SELECT id FROM public.emails WHERE arrived_at IS NULL LIMIT 5000)'
+            );
+        } while ($n > 0);
+
+        // 3) arrived_at 並び替え index (received_at 系と同形)
+        DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS emails_tenant_arrived_at_idx '
+            . 'ON public.emails USING btree (tenant_id, arrived_at DESC)');
+        DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS emails_tenant_category_arrived_at_idx '
+            . 'ON public.emails USING btree (tenant_id, category, arrived_at DESC)');
+
+        // 4) created_at 並び替え index を撤去 (arrived_at へ移行)
+        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS public.emails_tenant_created_at_idx');
+        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS public.emails_tenant_category_created_at_idx');
+    }
+
+    public function down(): void
+    {
+        if (DB::connection()->getDriverName() === 'pgsql') {
+            DB::statement('SET statement_timeout = 0');
+            DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS emails_tenant_created_at_idx '
+                . 'ON public.emails USING btree (tenant_id, created_at DESC)');
+            DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS emails_tenant_category_created_at_idx '
+                . 'ON public.emails USING btree (tenant_id, category, created_at DESC)');
+            DB::statement('DROP INDEX CONCURRENTLY IF EXISTS public.emails_tenant_arrived_at_idx');
+            DB::statement('DROP INDEX CONCURRENTLY IF EXISTS public.emails_tenant_category_arrived_at_idx');
+        }
+        if (Schema::hasColumn('emails', 'arrived_at')) {
+            Schema::table('emails', function (Blueprint $table) {
+                $table->dropColumn('arrived_at');
+            });
+        }
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -35,7 +35,7 @@ Schedule::call(function () {
         Log::info("[Schedule] KagoyaPOP3 同期完了: {$count}件");
     }
 })
-    ->everyFifteenMinutes()
+    ->everyFiveMinutes()
     ->name('sync-kagoya-pop3')
     ->withoutOverlapping()
     ->onFailure(function () {


### PR DESCRIPTION
## 概要
webmail と同じ**受信(到着)時刻**でメール一覧を並べ・表示する。3つの時刻を区別:
- 送信 = `received_at`(Date ヘッダ) … Kagoya 配送遅延で古い
- **受信(到着) = `arrived_at`(IMAP INTERNALDATE)** … Kagoya 着信時刻 = webmail と一致 ★
- 取込 = `created_at` … ポーリングラグ(最大5分)を含む

## 変更
- `emails.arrived_at` 追加。既存行は `created_at` で backfill(index 作成前=HOT・LIMIT バッチ)
- `KagoyaMailService`: 取込時に INTERNALDATE を `arrived_at` へ保存
- `EmailController::index` の並びを `arrived_at` 降順に(received_at の意味は不変)
- index 入替: 先行追加(#33)の created_at 並び替え index を撤去し `arrived_at` 複合 index 2本を CONCURRENTLY 作成(INSERT専用=HOT非阻害)
- **Kagoya 取込間隔 15分 → 5分**
- EmailFactory に arrived_at 追加

## 検証
- EXPLAIN: `emails_tenant_arrived_at_idx` 使用・Index Scan
- EmailSearchTest green

## デプロイ
- migration あり(列追加+backfill 20万行+CONCURRENTLY index 入替)。`migrate --force` 必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)